### PR TITLE
Upgrade postgres dep

### DIFF
--- a/src/deps/postgres.ts
+++ b/src/deps/postgres.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/postgres@v0.16.1/mod.ts";
+export * from "https://deno.land/x/postgres@v0.17.0/mod.ts";

--- a/src/postgres/postgres-driver.ts
+++ b/src/postgres/postgres-driver.ts
@@ -104,7 +104,7 @@ class PostgresConnection implements DatabaseConnection {
 
       if (result.command === "UPDATE" || result.command === "DELETE") {
         return {
-          numUpdatedOrDeletedRows: BigInt(result.rowCount!),
+          numAffectedRows: BigInt(result.rowCount!),
           rows: result.rows ?? [],
         };
       }


### PR DESCRIPTION
To support scram-sha-256 auth, which is default in postgres docker images v14+

What lead me here: https://stackoverflow.com/questions/75162143/why-is-postgres-password-authentication-failing-in-deno/75163296#75163296